### PR TITLE
Add passport-azure-ad

### DIFF
--- a/docker/package.json
+++ b/docker/package.json
@@ -17,6 +17,7 @@
     "@passport-next/passport-google-oauth2": "^1.0.0",
     "basic-auth": "^2.0.1",
     "passport": "^0.6.0",
+    "passport-azure-ad": "^4.3.3",
     "unleash-server": "file:../build"
   },
   "resolutions": {


### PR DESCRIPTION
Add passport-azure-ad to make example https://github.com/Unleash/unleash-examples/tree/main/v4/securing-azure-auth work with docker build and Helmchart.